### PR TITLE
Implemented decoding of ZigZag-encoded varints.

### DIFF
--- a/lib/jsgo.js
+++ b/lib/jsgo.js
@@ -664,6 +664,11 @@
         return this.varInt(4);
     }
 
+    BitStream.prototype.signedVarInt32 = function() {
+      var n = this.varInt32();
+      return ((n >> 1) ^ -(n & 1)) | 0;
+    }
+
     BitStream.prototype.varInt64 = function() {
         return this.varInt(8); // yeah whatever. it wont read a valid int64 for now.
     }


### PR DESCRIPTION
The parser breaks with the netcode from the 13501-update. This fixes it. 

Source for the implementation: [The official parser](https://github.com/csgo-data/demoinfogo-mirror/blob/2c8134c474fe7f3e02688b30249fe3cdc107ebc1/demofilebitbuf.h#L85)
